### PR TITLE
Initial service history open api additions

### DIFF
--- a/veteran-verification-api/pom.xml
+++ b/veteran-verification-api/pom.xml
@@ -25,6 +25,12 @@
       <artifactId>spring-beans</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <distributionManagement>
     <repository>

--- a/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/Attributes.java
+++ b/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/Attributes.java
@@ -1,0 +1,6 @@
+package gov.va.api.lighthouse.veteranverification.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "Attributes", implementation = ServiceHistoryAttributes.class)
+public interface Attributes {}

--- a/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/BranchOfService.java
+++ b/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/BranchOfService.java
@@ -1,0 +1,7 @@
+package gov.va.api.lighthouse.veteranverification.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// this object will appear as a string to the api user
+@Schema(description = "military branch of service", type = "string")
+public class BranchOfService {}

--- a/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/Deployment.java
+++ b/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/Deployment.java
@@ -1,0 +1,18 @@
+package gov.va.api.lighthouse.veteranverification.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Date;
+
+@Schema(type = "Object", description = "military episode deployment")
+public class Deployment {
+  @Schema(name = "start_date", description = "deployment start date", example = "2000-01-20")
+  Date startDate;
+
+  @Schema(name = "end_date", description = "deployment end date", example = "2001-01-20")
+  Date endDate;
+
+  @Schema(name = "location", description = "deployment location", example = "AFG")
+  Location location;
+
+  enum Location {}
+}

--- a/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/Deployment.java
+++ b/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/Deployment.java
@@ -1,17 +1,41 @@
 package gov.va.api.lighthouse.veteranverification.api;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Date;
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.Accessors;
 
+@Value
+@Builder
+@Accessors(fluent = false)
 @Schema(type = "Object", description = "military episode deployment")
+@SuppressFBWarnings({"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
 public class Deployment {
-  @Schema(name = "start_date", description = "deployment start date", example = "2000-01-20")
+
+  @Schema(
+      name = "start_date",
+      description = "deployment start date",
+      example = "2000-01-20",
+      required = true,
+      nullable = true)
   Date startDate;
 
-  @Schema(name = "end_date", description = "deployment end date", example = "2001-01-20")
+  @Schema(
+      name = "end_date",
+      description = "deployment end date",
+      example = "2001-01-20",
+      required = true,
+      nullable = true)
   Date endDate;
 
-  @Schema(name = "location", description = "deployment location", example = "AFG")
+  @Schema(
+      name = "location",
+      description = "deployment location",
+      example = "AFG",
+      required = true,
+      nullable = true)
   Location location;
 
   enum Location {}

--- a/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/PayGrade.java
+++ b/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/PayGrade.java
@@ -1,0 +1,7 @@
+package gov.va.api.lighthouse.veteranverification.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// this object will appear as a string to the api user
+@Schema(type = "String", description = "pay grade for military service episode")
+public class PayGrade {}

--- a/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/ServiceHistoryAttributes.java
+++ b/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/ServiceHistoryAttributes.java
@@ -1,0 +1,60 @@
+package gov.va.api.lighthouse.veteranverification.api;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Date;
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+@Value
+@Builder
+@Accessors(fluent = false)
+@Schema(
+    name = "ServiceHistoryAttributes",
+    type = "Object",
+    description = "Attributes for veteran verification service_history endpoint")
+@SuppressFBWarnings({"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
+public class ServiceHistoryAttributes implements Attributes {
+  @Schema(name = "first_name", description = "first name", example = "John")
+  String firstName;
+
+  @Schema(name = "last_name", description = "last name", example = "Doe")
+  String lastName;
+
+  @Schema(
+      name = "branch_of_service",
+      description = "military branch of service",
+      example = "Air Force")
+  BranchOfService branchOfService;
+
+  @Schema(name = "start_date", description = "military episode start date", example = "2000-01-20")
+  Date startDate;
+
+  @Schema(name = "end_date", description = "military episode end date", example = "2001-01-20")
+  Date endDate;
+
+  @Schema(implementation = PayGrade.class)
+  PayGrade payGrade;
+
+  @Schema(
+      name = "discharge_status",
+      description = "discharge status for military episode",
+      example = "honorable")
+  DischargeStatus dischargeStatus;
+
+  @Schema(
+      name = "separation_reason",
+      description = "separation reason for military episode",
+      example = "SUFFICIENT SERVICE FOR RETIREMENT")
+  SeparationReason separationReason;
+
+  @ArraySchema(schema = @Schema(implementation = Deployment.class))
+  List<Deployment> deployments;
+
+  enum DischargeStatus {}
+
+  enum SeparationReason {}
+}

--- a/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/VeteranVerificationResponse.java
+++ b/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/VeteranVerificationResponse.java
@@ -1,0 +1,25 @@
+package gov.va.api.lighthouse.veteranverification.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+/** Attributes object model. */
+@Data
+@Builder
+@Accessors(fluent = false)
+@Schema(
+    name = "VeteranVerificationResponse",
+    description = "Generic response object for veteran verification calls",
+    type = "object")
+public class VeteranVerificationResponse {
+  @Schema(type = "string", description = "Confirmation ICN", example = "1012667145V762142")
+  String id;
+
+  @Schema(type = "string", example = "veteran_status_confirmations")
+  String type;
+
+  @Schema(implementation = Attributes.class)
+  Attributes attributes;
+}

--- a/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/VeteranVerificationService.java
+++ b/veteran-verification-api/src/main/java/gov/va/api/lighthouse/veteranverification/api/VeteranVerificationService.java
@@ -74,6 +74,24 @@ import javax.ws.rs.Path;
 @Path("/")
 public interface VeteranVerificationService {
   @GET
+  @Path("service_history")
+  @ApiResponse(
+      responseCode = "200",
+      description = "Veteran service history successfully retrieved",
+      content = {
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = VeteranVerificationResponse.class))
+      })
+  @ApiResponse(responseCode = "401", description = "Not authorized")
+  @Operation(
+      operationId = "getServiceHistory",
+      summary = "Get confirmation about an individual's Veteran status according to the VA",
+      security = {@SecurityRequirement(name = "bearer_token")})
+  @Tag(name = "Veteran Verification")
+  VeteranVerificationResponse service_history();
+
+  @GET
   @Path("status")
   @ApiResponse(
       responseCode = "200",

--- a/veteran-verification/pom.xml
+++ b/veteran-verification/pom.xml
@@ -93,6 +93,7 @@
               <contextId>vv-openapi</contextId>
               <resourceClasses>
                 <resourceClass>gov.va.api.lighthouse.veteranverification.api.VeteranVerificationService</resourceClass>
+                <resourceClass>gov.va.api.lighthouse.veteranverification.api.ServiceHistoryAttributes</resourceClass>
               </resourceClasses>
               <outputFileName>veteran-verification-openapi</outputFileName>
               <outputPath>${project.build.outputDirectory}</outputPath>


### PR DESCRIPTION
**Service History Fields**

- data 
  - [ ] required - YES
- data.id
  - [ ] required - YES
  - [ ] nullable - NO
- data.attributes
  - [ ] required - YES
- data.attributes.first_name
  - [ ] required - YES
  - [ ] nullable - NO
- data.attributes.last_name
  - [ ] required - YES
  - [ ] nullable - NO
- data.attributes.branch_of_service
  - [ ] required - YES
  - [ ] nullable - NO - functionally it may be an empty string
- data.attributes.start_date
  - [ ] required - YES
  - [ ] nullable - YES
- data.attributes.end_date
  - [ ] required - YES
  - [ ] nullable - YES
- data.attributes.pay_grade
  - [ ] required - YES
  - [ ] nullable - NO
- data.attributes.discharge_status
  - [ ] required - YES
  - [ ] nullable - YES
- data.attributes.separation_reason
  - [ ] required - YES
  - [ ] nullable - NO
- data.attributes.deployments
  - [ ] can it be empty? - yes
  - [ ] required - YES
- data.attributes.deployments.start_date
  - [x] required - YES
  - [x] nullable - YES
- data.attributes.deployments.end_date
  - [x] required - YES
  - [x] nullable - YES
- data.attributes.deployments.location
  - [x] required - YES
  - [x] nullable - YES