### PR TITLE
Refactored Notary

### DIFF
--- a/veteran-verification/pom.xml
+++ b/veteran-verification/pom.xml
@@ -28,6 +28,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>${nimbus-jose-jwt.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
       <version>${java-jwt.version}</version>

--- a/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/utils/Notary.java
+++ b/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/utils/Notary.java
@@ -1,21 +1,20 @@
 package gov.va.api.lighthouse.veteranverification.service.utils;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jwt.JWTClaimsSet;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.math.BigInteger;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.security.KeyPair;
 import java.security.MessageDigest;
-import java.security.Security;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
 import java.util.Map;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -24,16 +23,10 @@ import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1OutputStream;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERSequence;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMKeyPair;
-import org.bouncycastle.openssl.PEMParser;
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.util.encoders.Hex;
 
 public class Notary {
-  private RSAPrivateKey privateKey;
-
-  private RSAPublicKey publicKey;
+  private final JWK privateKey;
 
   /**
    * Builder for Notary.
@@ -42,30 +35,36 @@ public class Notary {
    */
   @SneakyThrows
   public Notary(@NonNull File privateKey) {
-    KeyPair kp = readKeyPair(privateKey);
-    this.publicKey = (RSAPublicKey) kp.getPublic();
-    this.privateKey = (RSAPrivateKey) kp.getPrivate();
+    this.privateKey = JWK.parseFromPEMEncodedObjects(Files.readString(privateKey.toPath()));
   }
 
   @SneakyThrows
   private String kid() {
-    BigInteger e = publicKey.getPublicExponent();
-    BigInteger n = publicKey.getModulus();
     ASN1EncodableVector vector = new ASN1EncodableVector();
-    vector.add(new ASN1Integer(n));
-    vector.add(new ASN1Integer(e));
-
+    vector.add(new ASN1Integer(privateKey.toRSAKey().getModulus().decodeToBigInteger()));
+    vector.add(new ASN1Integer(privateKey.toRSAKey().getPublicExponent().decodeToBigInteger()));
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     ASN1OutputStream asnOs = new ASN1OutputStream(baos);
-
     asnOs.writeObject(new DERSequence(vector));
     asnOs.flush();
-
     ASN1Sequence sequence = (ASN1Sequence) ASN1Sequence.fromByteArray(baos.toByteArray());
-
     MessageDigest digest = MessageDigest.getInstance("SHA-256");
     byte[] hash = digest.digest(sequence.getEncoded());
     return new String(Hex.encode(hash), StandardCharsets.UTF_8);
+  }
+
+  @SuppressWarnings("unchecked")
+  private JWTClaimsSet objectToClaimSet(Object object) {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    Map<String, Object> claimsMap =
+        (Map<String, Object>) objectMapper.convertValue(object, Map.class);
+    JWTClaimsSet.Builder jwtClaimsBuilder = new JWTClaimsSet.Builder();
+    for (Map.Entry<String, Object> entry : claimsMap.entrySet()) {
+      jwtClaimsBuilder.claim(entry.getKey(), entry.getValue());
+    }
+    return jwtClaimsBuilder.build();
   }
 
   /**
@@ -74,27 +73,14 @@ public class Notary {
    * @param object object to be converted into a jwt.
    * @return Jwt representation of the map.
    */
-  public String objectToJwt(Object object) {
-    Map<String, Object> map = objectToMap(object);
-    Algorithm algorithmRs = Algorithm.RSA256(publicKey, privateKey);
-    return JWT.create().withKeyId(kid()).withPayload(map).sign(algorithmRs);
-  }
-
-  @SuppressWarnings("unchecked")
-  private Map<String, Object> objectToMap(Object object) {
-    ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.registerModule(new JavaTimeModule());
-    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
-    return (Map<String, Object>) objectMapper.convertValue(object, Map.class);
-  }
-
-  private KeyPair readKeyPair(File file) throws Exception {
-    Security.addProvider(new BouncyCastleProvider());
-    try (PEMParser pemParser =
-        new PEMParser(Files.newBufferedReader(file.toPath(), Charset.defaultCharset())); ) {
-      JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
-      Object object = pemParser.readObject();
-      return converter.getKeyPair((PEMKeyPair) object);
-    }
+  @SuppressWarnings("deprecation")
+  @SneakyThrows
+  public String objectToJwt(@NonNull Object object) {
+    JWSObject jwsObject =
+        new JWSObject(
+            new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(kid()).type(JOSEObjectType.JWT).build(),
+            objectToClaimSet(object).toPayload());
+    jwsObject.sign(new RSASSASigner(privateKey.toRSAKey(), true));
+    return jwsObject.serialize();
   }
 }

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
@@ -20,7 +20,7 @@ public class NotaryTest {
 
   @Test
   @SneakyThrows
-  public void objectToJwObjectIsNonNull() {
+  public void objectToJwtObjectIsNonNull() {
     Notary notary = new Notary(new File("src/test/resources/verification_test_private.pem"));
     Assertions.assertThrows(
         NullPointerException.class,

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
@@ -10,6 +10,26 @@ import org.junit.jupiter.api.Test;
 
 public class NotaryTest {
   @Test
+  public void constructorFileIsNonNull() {
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          new Notary(null);
+        });
+  }
+
+  @Test
+  @SneakyThrows
+  public void objectToJwObjectIsNonNull() {
+    Notary notary = new Notary(new File("src/test/resources/verification_test_private.pem"));
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          notary.objectToJwt(null);
+        });
+  }
+
+  @Test
   @SneakyThrows
   public void objectToJwtHappyPath() {
     ServiceHistoryResponse.ServiceHistoryEpisode[] serviceHistoryEpisodes = {


### PR DESCRIPTION
# Description

The goal of this PR was to simplify the Notary class. Using Jose opposed to bouncy castle removes the pem parsing logic. Jose is also used by the health-apis-smart-cards repository, so there is consistency across the project.

## Things to consider

The notary object was created to replicate vets-api exactly. There are a couple aspects that I believe we could change if we wanted to do so. 

1. To ensure the keyId was the same between vets-api and the this project, I used the same test key. This key is not a 2056 bit key, so it is considered weak. We are allowing weak keys for now. Since we know the keyId logic is identical between repositories, I think it would be fine to swap this key with a stronger key.

2. The vets-api keyId logic is taken from the [ruby-jwt](https://github.com/jwt/ruby-jwt/blob/master/lib/jwt/jwk/rsa.rb#L39) library. After reading the RFC JWK [specs](https://datatracker.ietf.org/doc/html/rfc7517#section-4.5), I have realized that the implementation of the kid is not defined. The kid could be any identifying value. 

   The current keyId logic will produce a unique id, but seems to be only implemented by the ruby-jwt project (If this is not the case please let me know). If we did not want to maintain this logic we could use the key thumbprint which jose supports. Thumbprints are used as keys as seen in these connect2id [docs](https://connect2id.com/products/nimbus-jose-jwt/examples/jwk-thumbprints) and also seemed to be the keyId used by the health-apis-smart-card [project](https://github.com/department-of-veterans-affairs/health-apis-smart-cards/blob/master/pem-to-jwk/src/main/java/gov/va/api/pem2jwk/Pem2JwkConverter.java#L28).

Please let me know your thoughts on these potential changes.