### PR TITLE
Refactor Notary Take Two

### DIFF
--- a/veteran-verification/pom.xml
+++ b/veteran-verification/pom.xml
@@ -28,6 +28,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>${nimbus-jose-jwt.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
       <version>${java-jwt.version}</version>

--- a/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/utils/JwksProperties.java
+++ b/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/utils/JwksProperties.java
@@ -1,0 +1,47 @@
+package gov.va.api.lighthouse.veteranverification.service.utils;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import java.security.KeyStore;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Value;
+
+@Getter
+public class JwksProperties {
+  private final JWKSet jwksPrivate;
+  private final JWKSet jwksPublic;
+  private final String jwksPublicJson;
+  private String currentKeyId;
+
+  /** Constructor. */
+  @SneakyThrows
+  public JwksProperties(
+      @NonNull KeyStore keyStore,
+      @NonNull @Value("${jwk-set.current-key-id}") String currentKeyId,
+      @NonNull @Value("${jwk-set.current-password}") String currentKeyPassword) {
+    this.jwksPrivate = JWKSet.load(keyStore, name -> currentKeyPassword.toCharArray());
+    this.jwksPublic = jwksPrivate.toPublicJWKSet();
+    this.jwksPublicJson = jwksPublic.toString();
+    this.currentKeyId = currentKeyId;
+  }
+
+  /**
+   * Gets Private JWK by the keyId specified in the constructor.
+   *
+   * @return Private JWK.
+   */
+  public JWK currentPrivateJwk() {
+    return jwksPrivate.getKeyByKeyId(currentKeyId);
+  }
+
+  /**
+   * Gets Public JWK by the keyId specified in the constructor.
+   *
+   * @return Public JWK.
+   */
+  public JWK currentPublicJwk() {
+    return jwksPublic.getKeyByKeyId(currentKeyId);
+  }
+}

--- a/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/utils/Notary.java
+++ b/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/utils/Notary.java
@@ -1,21 +1,20 @@
 package gov.va.api.lighthouse.veteranverification.service.utils;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jwt.JWTClaimsSet;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.math.BigInteger;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.security.KeyPair;
 import java.security.MessageDigest;
-import java.security.Security;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
 import java.util.Map;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -24,16 +23,10 @@ import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1OutputStream;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERSequence;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMKeyPair;
-import org.bouncycastle.openssl.PEMParser;
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.util.encoders.Hex;
 
 public class Notary {
-  private RSAPrivateKey privateKey;
-
-  private RSAPublicKey publicKey;
+  private final JWK privateKey;
 
   /**
    * Builder for Notary.
@@ -42,30 +35,36 @@ public class Notary {
    */
   @SneakyThrows
   public Notary(@NonNull File privateKey) {
-    KeyPair kp = readKeyPair(privateKey);
-    this.publicKey = (RSAPublicKey) kp.getPublic();
-    this.privateKey = (RSAPrivateKey) kp.getPrivate();
+    this.privateKey = JWK.parseFromPEMEncodedObjects(Files.readString(privateKey.toPath()));
   }
 
   @SneakyThrows
   private String kid() {
-    BigInteger e = publicKey.getPublicExponent();
-    BigInteger n = publicKey.getModulus();
     ASN1EncodableVector vector = new ASN1EncodableVector();
-    vector.add(new ASN1Integer(n));
-    vector.add(new ASN1Integer(e));
-
+    vector.add(new ASN1Integer(privateKey.toRSAKey().getModulus().decodeToBigInteger()));
+    vector.add(new ASN1Integer(privateKey.toRSAKey().getPublicExponent().decodeToBigInteger()));
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     ASN1OutputStream asnOs = new ASN1OutputStream(baos);
-
     asnOs.writeObject(new DERSequence(vector));
     asnOs.flush();
-
     ASN1Sequence sequence = (ASN1Sequence) ASN1Sequence.fromByteArray(baos.toByteArray());
-
     MessageDigest digest = MessageDigest.getInstance("SHA-256");
     byte[] hash = digest.digest(sequence.getEncoded());
     return new String(Hex.encode(hash), StandardCharsets.UTF_8);
+  }
+
+  @SuppressWarnings("unchecked")
+  private JWTClaimsSet objectToClaimSet(Object object) {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    Map<String, Object> claimsMap =
+        (Map<String, Object>) objectMapper.convertValue(object, Map.class);
+    JWTClaimsSet.Builder jwtClaimsBuilder = new JWTClaimsSet.Builder();
+    for (Map.Entry<String, Object> entry : claimsMap.entrySet()) {
+      jwtClaimsBuilder.claim(entry.getKey(), entry.getValue());
+    }
+    return jwtClaimsBuilder.build();
   }
 
   /**
@@ -74,27 +73,14 @@ public class Notary {
    * @param object object to be converted into a jwt.
    * @return Jwt representation of the map.
    */
-  public String objectToJwt(Object object) {
-    Map<String, Object> map = objectToMap(object);
-    Algorithm algorithmRs = Algorithm.RSA256(publicKey, privateKey);
-    return JWT.create().withKeyId(kid()).withPayload(map).sign(algorithmRs);
-  }
-
-  @SuppressWarnings("unchecked")
-  private Map<String, Object> objectToMap(Object object) {
-    ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.registerModule(new JavaTimeModule());
-    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
-    return (Map<String, Object>) objectMapper.convertValue(object, Map.class);
-  }
-
-  private KeyPair readKeyPair(File file) throws Exception {
-    Security.addProvider(new BouncyCastleProvider());
-    try (PEMParser pemParser =
-        new PEMParser(Files.newBufferedReader(file.toPath(), Charset.defaultCharset())); ) {
-      JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
-      Object object = pemParser.readObject();
-      return converter.getKeyPair((PEMKeyPair) object);
-    }
+  @SuppressWarnings("deprecation")
+  @SneakyThrows
+  public String objectToJwt(@NonNull Object object) {
+    JWSObject jwsObject =
+        new JWSObject(
+            new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(kid()).type(JOSEObjectType.JWT).build(),
+            objectToClaimSet(object).toPayload());
+    jwsObject.sign(new RSASSASigner(privateKey.toRSAKey(), true));
+    return jwsObject.serialize();
   }
 }

--- a/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/utils/Notary.java
+++ b/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/utils/Notary.java
@@ -8,50 +8,16 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSObject;
 import com.nimbusds.jose.crypto.RSASSASigner;
-import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jwt.JWTClaimsSet;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.security.MessageDigest;
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.SneakyThrows;
-import org.bouncycastle.asn1.ASN1EncodableVector;
-import org.bouncycastle.asn1.ASN1Integer;
-import org.bouncycastle.asn1.ASN1OutputStream;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DERSequence;
-import org.bouncycastle.util.encoders.Hex;
+import org.springframework.beans.factory.annotation.Autowired;
 
+@AllArgsConstructor(onConstructor_ = @Autowired)
 public class Notary {
-  private final JWK privateKey;
-
-  /**
-   * Builder for Notary.
-   *
-   * @param privateKey File that contains the private key.
-   */
-  @SneakyThrows
-  public Notary(@NonNull File privateKey) {
-    this.privateKey = JWK.parseFromPEMEncodedObjects(Files.readString(privateKey.toPath()));
-  }
-
-  @SneakyThrows
-  private String kid() {
-    ASN1EncodableVector vector = new ASN1EncodableVector();
-    vector.add(new ASN1Integer(privateKey.toRSAKey().getModulus().decodeToBigInteger()));
-    vector.add(new ASN1Integer(privateKey.toRSAKey().getPublicExponent().decodeToBigInteger()));
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    ASN1OutputStream asnOs = new ASN1OutputStream(baos);
-    asnOs.writeObject(new DERSequence(vector));
-    asnOs.flush();
-    ASN1Sequence sequence = (ASN1Sequence) ASN1Sequence.fromByteArray(baos.toByteArray());
-    MessageDigest digest = MessageDigest.getInstance("SHA-256");
-    byte[] hash = digest.digest(sequence.getEncoded());
-    return new String(Hex.encode(hash), StandardCharsets.UTF_8);
-  }
+  @NonNull private final JwksProperties jwksProperties;
 
   @SuppressWarnings("unchecked")
   private JWTClaimsSet objectToClaimSet(Object object) {
@@ -73,14 +39,16 @@ public class Notary {
    * @param object object to be converted into a jwt.
    * @return Jwt representation of the map.
    */
-  @SuppressWarnings("deprecation")
   @SneakyThrows
   public String objectToJwt(@NonNull Object object) {
     JWSObject jwsObject =
         new JWSObject(
-            new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(kid()).type(JOSEObjectType.JWT).build(),
+            new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .keyID(jwksProperties.currentKeyId())
+                .type(JOSEObjectType.JWT)
+                .build(),
             objectToClaimSet(object).toPayload());
-    jwsObject.sign(new RSASSASigner(privateKey.toRSAKey(), true));
+    jwsObject.sign(new RSASSASigner(jwksProperties.currentPrivateJwk().toRSAKey()));
     return jwsObject.serialize();
   }
 }

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/JwksPropertiesTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/JwksPropertiesTest.java
@@ -1,0 +1,112 @@
+package gov.va.api.lighthouse.veteranverification.service.utils;
+
+import com.nimbusds.jose.jwk.JWK;
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class JwksPropertiesTest {
+  @Test
+  @SneakyThrows
+  public void currentKeyIdHappyPath() {
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    Assertions.assertEquals("fake", jwksProperties.currentKeyId());
+  }
+
+  @Test
+  @SneakyThrows
+  public void currentKeyIdIsNonNull() {
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          new JwksProperties(ks, null, "secret");
+        });
+  }
+
+  @Test
+  @SneakyThrows
+  public void currentKeyPasswordIsNonNull() {
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          new JwksProperties(ks, "fake", null);
+        });
+  }
+
+  @Test
+  @SneakyThrows
+  public void currentPrivateJwkHappyPath() {
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    Assertions.assertNotNull(jwksProperties.currentPrivateJwk());
+  }
+
+  @Test
+  @SneakyThrows
+  public void currentPublicJwkHappyPath() {
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    Assertions.assertNotNull(jwksProperties.currentPublicJwk());
+  }
+
+  @Test
+  @SneakyThrows
+  public void jwksPrivateHappyPath() {
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    List<JWK> keys = new JwksProperties(ks, "fake", "secret").jwksPrivate().getKeys();
+    Assertions.assertEquals(1, keys.size());
+    Assertions.assertEquals("RSA", keys.get(0).getKeyType().toString());
+    Assertions.assertEquals(
+        "9nySB6kHPzMIg__xHs0erFz5mZyaGzdI_u3omSR1_qk",
+        keys.get(0).getX509CertSHA256Thumbprint().toString());
+    Assertions.assertEquals("fake", keys.get(0).getKeyID());
+    Assertions.assertEquals(1, keys.get(0).getParsedX509CertChain().size());
+    Assertions.assertTrue(keys.get(0).isPrivate());
+  }
+
+  @Test
+  @SneakyThrows
+  public void jwksPublicHappyPath() {
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    List<JWK> keys = new JwksProperties(ks, "fake", "secret").jwksPublic().getKeys();
+    Assertions.assertEquals(1, keys.size());
+    Assertions.assertEquals("RSA", keys.get(0).getKeyType().toString());
+    Assertions.assertEquals(
+        "9nySB6kHPzMIg__xHs0erFz5mZyaGzdI_u3omSR1_qk",
+        keys.get(0).getX509CertSHA256Thumbprint().toString());
+    Assertions.assertEquals("fake", keys.get(0).getKeyID());
+    Assertions.assertEquals(1, keys.get(0).getParsedX509CertChain().size());
+    Assertions.assertFalse(keys.get(0).isPrivate());
+  }
+
+  @Test
+  @SneakyThrows
+  public void jwksPublicJsonHappyPath() {
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    Assertions.assertNotNull(jwksProperties.jwksPublicJson());
+  }
+
+  @Test
+  public void keyStoreIsNonNull() {
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          new JwksProperties(null, "fake", "secret");
+        });
+  }
+}

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
@@ -2,7 +2,8 @@ package gov.va.api.lighthouse.veteranverification.service.utils;
 
 import gov.va.api.lighthouse.veteranverification.api.v0.ServiceHistoryResponse;
 import gov.va.api.lighthouse.veteranverification.service.TestUtils;
-import java.io.File;
+import java.io.FileInputStream;
+import java.security.KeyStore;
 import java.util.Arrays;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
@@ -10,22 +11,11 @@ import org.junit.jupiter.api.Test;
 
 public class NotaryTest {
   @Test
-  public void constructorFileIsNonNull() {
+  public void jwksPropertiesIsNonNull() {
     Assertions.assertThrows(
         NullPointerException.class,
         () -> {
           new Notary(null);
-        });
-  }
-
-  @Test
-  @SneakyThrows
-  public void objectToJwtObjectIsNonNull() {
-    Notary notary = new Notary(new File("src/test/resources/verification_test_private.pem"));
-    Assertions.assertThrows(
-        NullPointerException.class,
-        () -> {
-          notary.objectToJwt(null);
         });
   }
 
@@ -39,21 +29,39 @@ public class NotaryTest {
         ServiceHistoryResponse.builder()
             .data(Arrays.stream(serviceHistoryEpisodes).toList())
             .build();
-    Notary notary = new Notary(new File("src/test/resources/verification_test_private.pem"));
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    Notary notary = new Notary(jwksProperties);
     String jwt = notary.objectToJwt(serviceHistoryResponse);
     Assertions.assertEquals(
-        "eyJraWQiOiIwODhkMjQyMzJmZjZmYWE0Y2Q0Y2ZlYzEyNmFkMDQzMWRmZjFlYTAyOGFmZGIxYzg2YjM3MThkNzAxN"
-            + "zFhZWQ2IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJkYXRhIjpbeyJpZCI6Im1vY2siLCJ0eXBlIjoic2Vydm"
-            + "ljZS1oaXN0b3J5LWVwaXNvZGVzIiwiYXR0cmlidXRlcyI6eyJmaXJzdF9uYW1lIjoiSm9obiIsImxhc3RfbmFtZSI6Ik"
-            + "RvZSIsImJyYW5jaF9vZl9zZXJ2aWNlIjoiQnJhbmNoT2ZTZXJ2aWNlIiwic3RhcnRfZGF0ZSI6IjIwMDAtMDEtMDEiLC"
-            + "JlbmRfZGF0ZSI6IjIwMDEtMDEtMDEiLCJwYXlfZ3JhZGUiOiJQYXlHcmFkZSIsImRpc2NoYXJnZV9zdGF0dXMiOiJob2"
-            + "5vcmFibGUiLCJzZXBhcmF0aW9uX3JlYXNvbiI6IlNlcGFyYXRpb25SZWFzb24iLCJkZXBsb3ltZW50cyI6W3sic3Rhcn"
-            + "RfZGF0ZSI6IjIwMDAtMDItMDEiLCJlbmRfZGF0ZSI6IjIwMDEtMDEtMDEiLCJsb2NhdGlvbiI6IkFGRyJ9LHsic3Rhcn"
-            + "RfZGF0ZSI6IjIwMDItMDItMDEiLCJlbmRfZGF0ZSI6IjIwMDMtMDEtMDEiLCJsb2NhdGlvbiI6IkFGRyJ9LHsic3Rhcn"
-            + "RfZGF0ZSI6IjIwMDQtMDItMDEiLCJlbmRfZGF0ZSI6IjIwMDUtMDEtMDEiLCJsb2NhdGlvbiI6IkFGRyJ9LHsic3Rhcn"
-            + "RfZGF0ZSI6IjIwMDYtMDItMDEiLCJlbmRfZGF0ZSI6IjIwMDctMDEtMDEiLCJsb2NhdGlvbiI6IkFGRyJ9XX19XX0.uM"
-            + "bTDYFXSfdJovBJMOdlPwF9USHGOd6ksG-ZJrBnOa8vwFBQ-h6lDV6qg73W_gt64DwXj1wT4o-NUiS5rfs9czLwx-Ck9V"
-            + "PHmatQZVyrnWkHkWPLlWve11kIs1nHOWEG1m28zug4s5SyafGfC6whmXb6VKlWtY_Ll6Gy0dMQqns",
+        "eyJraWQiOiJmYWtlIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJkYXRhIjpbeyJpZCI6Im1vY2siLCJ0eX"
+            + "BlIjoic2VydmljZS1oaXN0b3J5LWVwaXNvZGVzIiwiYXR0cmlidXRlcyI6eyJmaXJzdF9uYW1lIjoiSm9obiIsImxhc3R"
+            + "fbmFtZSI6IkRvZSIsImJyYW5jaF9vZl9zZXJ2aWNlIjoiQnJhbmNoT2ZTZXJ2aWNlIiwic3RhcnRfZGF0ZSI6IjIwMDAt"
+            + "MDEtMDEiLCJlbmRfZGF0ZSI6IjIwMDEtMDEtMDEiLCJwYXlfZ3JhZGUiOiJQYXlHcmFkZSIsImRpc2NoYXJnZV9zdGF0d"
+            + "XMiOiJob25vcmFibGUiLCJzZXBhcmF0aW9uX3JlYXNvbiI6IlNlcGFyYXRpb25SZWFzb24iLCJkZXBsb3ltZW50cyI6W3"
+            + "sic3RhcnRfZGF0ZSI6IjIwMDAtMDItMDEiLCJlbmRfZGF0ZSI6IjIwMDEtMDEtMDEiLCJsb2NhdGlvbiI6IkFGRyJ9LHs"
+            + "ic3RhcnRfZGF0ZSI6IjIwMDItMDItMDEiLCJlbmRfZGF0ZSI6IjIwMDMtMDEtMDEiLCJsb2NhdGlvbiI6IkFGRyJ9LHsi"
+            + "c3RhcnRfZGF0ZSI6IjIwMDQtMDItMDEiLCJlbmRfZGF0ZSI6IjIwMDUtMDEtMDEiLCJsb2NhdGlvbiI6IkFGRyJ9LHsic"
+            + "3RhcnRfZGF0ZSI6IjIwMDYtMDItMDEiLCJlbmRfZGF0ZSI6IjIwMDctMDEtMDEiLCJsb2NhdGlvbiI6IkFGRyJ9XX19XX"
+            + "0.dmBxYrcELzUq0ntBHY2ZD2PvrCV6rNJBTuvXUr3VxXirzoY6vB4JPmTAznbviRjvS44D4z9uJat0UUhko9PoMRIfYCr"
+            + "MqY-9crbGVmu5P1RJoiHLxL_HAykygov3wMKC_yzeIS_IJ2UIw_NIzuaLZDuk9HE6WJCVcs0A_Yjiv6thRgVjUD-08gbT"
+            + "Q0Oz38UH3xdDSyNozUXH5AHFpkkC8DWl4MDg774oXiMBCAzjfw7uR4FFHXXAqZJZR7uPKVbASxCcmqHKH5JInnZjQ_1Fe"
+            + "QSxKF0FXQx-_XzjoIvKshS43_f3277ok_eT9zZlStzNrtLgZmuSLb3eSe8U6UFLkg",
         jwt);
+  }
+
+  @Test
+  @SneakyThrows
+  public void objectToJwtObjectIsNonNull() {
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "fake");
+    Notary notary = new Notary(jwksProperties);
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          notary.objectToJwt(null);
+        });
   }
 }

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
@@ -20,7 +20,7 @@ public class NotaryTest {
 
   @Test
   @SneakyThrows
-  public void objectToJwObjectIsNonNull() {
+  public void objectToJwtObjectIsNonNull() {
     Notary notary = new Notary(new File("src/test/resources/verification_test_private.pem"));
     Assertions.assertThrows(
         NullPointerException.class,

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
@@ -10,6 +10,26 @@ import org.junit.jupiter.api.Test;
 
 public class NotaryTest {
   @Test
+  public void constructorFileIsNonNull() {
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          new Notary(null);
+        });
+  }
+
+  @Test
+  @SneakyThrows
+  public void objectToJwObjectIsNonNull() {
+    Notary notary = new Notary(new File("src/test/resources/verification_test_private.pem"));
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          notary.objectToJwt(null);
+        });
+  }
+
+  @Test
   @SneakyThrows
   public void objectToJwtHappyPath() {
     ServiceHistoryResponse.ServiceHistoryEpisode[] serviceHistoryEpisodes = {


### PR DESCRIPTION
# Description

With the addition of the `/keys` endpoint I thought it would be necessary to implement a new pattern. I took this pattern directly from the smartcards [api](https://github.com/department-of-veterans-affairs/health-apis-smart-cards/blob/master/smart-cards/src/main/java/gov/va/api/health/smartcards/JwksProperties.java). 

## Design

All key handling logic is in the JwksProperties class. This class is only set up to deal with a single key, but could be easily extended to work with multiple if necessary in the future. Now the Notary class contains no key parsing logic itself. Is has a member JwksProperties field.

This new pattern assumes we are using keystores for our key management. For this reason we no longer have to do any keyId logic. We will assume the keyId is in the keystore.