### PR TITLE
Api 9501 keys controller

### DIFF
--- a/veteran-verification-tests/pom.xml
+++ b/veteran-verification-tests/pom.xml
@@ -157,6 +157,10 @@
                 <argument>-Demis.v1.wsdl-location=http://localhost:9000/VIERSService/eMIS/v1/VeteranStatusService/eMISVeteranStatusService.wsdl</argument>
                 <argument>-Dbgs.url=http://localhost:8000/v0/RatingServiceBean/RatingService</argument>
                 <argument>-Dbgs.wsdl-location=http://localhost:8000/v0/RatingServiceBean/RatingService/ratingRecord.wsdl</argument>
+                <argument>-Djwk-set.current-key-id=fake</argument>
+                <argument>-Djwk-set.current-password=secret</argument>
+                <argument>-Djwk-set.keystore-password=secret</argument>
+                <argument>-Djwk-set.keystore-path=${project.basedir}/../veteran-verification/src/test/resources/fakekeystore.jks</argument>
                 <argument>-Dloader=gov.va.api.lighthouse.veteranverification.service.Application</argument>
                 <argument>-Dlogging.level.root=INFO</argument>
                 <argument>-Dspring.config.additional-location=classpath:/application.properties,optional:file:${project.basedir}/config/secrets.properties</argument>

--- a/veteran-verification-tests/src/test/java/gov/va/api/lighthouse/veteranverification/tests/KeysIT.java
+++ b/veteran-verification-tests/src/test/java/gov/va/api/lighthouse/veteranverification/tests/KeysIT.java
@@ -1,0 +1,13 @@
+package gov.va.api.lighthouse.veteranverification.tests;
+
+import static gov.va.api.lighthouse.veteranverification.tests.Requestor.veteranVerificationGetRequest;
+
+import gov.va.api.health.sentinel.ExpectedResponse;
+import org.junit.jupiter.api.Test;
+
+public class KeysIT {
+  @Test
+  public void happyPath() {
+    ExpectedResponse response = veteranVerificationGetRequest("v0/keys", 200);
+  }
+}

--- a/veteran-verification/spotbugs-excludes.xml
+++ b/veteran-verification/spotbugs-excludes.xml
@@ -3,8 +3,8 @@
     <!-- Exclusions can be defined here and should include a comment on why the finding can be ignored -->
     <!--
     This finding is reported where keystores are loaded to configure the JwksProperties class.
-    explanation ... . Furthermore, this resource path is provided as configuration and is not user or
-    caller specified.
+    This resource path is provided as configuration and is not user or
+    caller specified. Also this keystore is local and cannot be changed without us knowing.
     -->
     <Match>
         <Class name="gov.va.api.lighthouse.veteranverification.service.utils.JwksProperties$JwksPropertiesBuilder"/>

--- a/veteran-verification/spotbugs-excludes.xml
+++ b/veteran-verification/spotbugs-excludes.xml
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FindBugsFilter></FindBugsFilter>
+<FindBugsFilter>
+    <!-- Exclusions can be defined here and should include a comment on why the finding can be ignored -->
+    <!--
+    This finding is reported where keystores are loaded to configure the JwksProperties class.
+    explanation ... . Furthermore, this resource path is provided as configuration and is not user or
+    caller specified.
+    -->
+    <Match>
+        <Class name="gov.va.api.lighthouse.veteranverification.service.utils.JwksProperties$JwksPropertiesBuilder"/>
+        <Bug pattern="URLCONNECTION_SSRF_FD"/>
+    </Match>
+</FindBugsFilter>

--- a/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/VeteranVerificationConfig.java
+++ b/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/VeteranVerificationConfig.java
@@ -12,7 +12,9 @@ import gov.va.api.lighthouse.emis.SoapEmisVeteranStatusServiceClient;
 import gov.va.api.lighthouse.mpi.MasterPatientIndexClient;
 import gov.va.api.lighthouse.mpi.MpiConfig;
 import gov.va.api.lighthouse.mpi.SoapMasterPatientIndexClient;
+import gov.va.api.lighthouse.veteranverification.service.utils.JwksProperties;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,15 +29,31 @@ public class VeteranVerificationConfig {
 
   private BgsConfig bgsConfig;
 
+  private String currentKeyId;
+
+  private String currentKeyPassword;
+
+  private String keyStorePassword;
+
+  private String keyStorePath;
+
   VeteranVerificationConfig(
       @Autowired MpiConfig mpiConfig,
       @Autowired EmisConfigV1 emisConfigV1,
       @Autowired EmisConfigV2 emisConfigV2,
-      @Autowired BgsConfig bgsConfig) {
+      @Autowired BgsConfig bgsConfig,
+      @Value("${jwk-set.current-key-id}") String currentKeyId,
+      @Value("${jwk-set.current-password}") String currentKeyPassword,
+      @Value("${jwk-set.keystore-password}") String keyStorePassword,
+      @Value("${jwk-set.keystore-path}") String keyStorePath) {
     this.mpiConfig = mpiConfig;
     this.emisConfigV1 = emisConfigV1;
     this.emisConfigV2 = emisConfigV2;
     this.bgsConfig = bgsConfig;
+    this.currentKeyId = currentKeyId;
+    this.currentKeyPassword = currentKeyPassword;
+    this.keyStorePassword = keyStorePassword;
+    this.keyStorePath = keyStorePath;
   }
 
   @Bean
@@ -51,6 +69,16 @@ public class VeteranVerificationConfig {
   @Bean
   public EmisVeteranStatusServiceClient emisVeteranStatusServiceClient() {
     return SoapEmisVeteranStatusServiceClient.of(emisConfigV1);
+  }
+
+  @Bean
+  JwksProperties jwksProperties() {
+    return JwksProperties.builder()
+        .currentKeyId(currentKeyId)
+        .currentKeyPassword(currentKeyPassword)
+        .keyStorePassword(keyStorePassword)
+        .keyStorePath(keyStorePath)
+        .build();
   }
 
   @Bean

--- a/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysController.java
+++ b/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysController.java
@@ -3,7 +3,11 @@ package gov.va.api.lighthouse.veteranverification.service.controller.keys;
 import gov.va.api.lighthouse.veteranverification.api.v0.JwkKeyset;
 import gov.va.api.lighthouse.veteranverification.service.utils.JwksProperties;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@RestController
+@RequestMapping(produces = {"application/json"})
 public class KeysController {
   JwksProperties jwksProperties;
 

--- a/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysController.java
+++ b/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysController.java
@@ -1,0 +1,18 @@
+package gov.va.api.lighthouse.veteranverification.service.controller.keys;
+
+import gov.va.api.lighthouse.veteranverification.api.v0.JwkKeyset;
+import gov.va.api.lighthouse.veteranverification.service.utils.JwksProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class KeysController {
+  JwksProperties jwksProperties;
+
+  public KeysController(@Autowired JwksProperties jwksProperties) {
+    this.jwksProperties = jwksProperties;
+  }
+
+  public JwkKeyset keyset() {
+    KeysTransformer transformer = KeysTransformer.builder().jwksProperties(jwksProperties).build();
+    return transformer.keysTransformer();
+  }
+}

--- a/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysController.java
+++ b/veteran-verification/src/main/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysController.java
@@ -3,6 +3,7 @@ package gov.va.api.lighthouse.veteranverification.service.controller.keys;
 import gov.va.api.lighthouse.veteranverification.api.v0.JwkKeyset;
 import gov.va.api.lighthouse.veteranverification.service.utils.JwksProperties;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,6 +16,7 @@ public class KeysController {
     this.jwksProperties = jwksProperties;
   }
 
+  @GetMapping({"/v0/keys"})
   public JwkKeyset keyset() {
     KeysTransformer transformer = KeysTransformer.builder().jwksProperties(jwksProperties).build();
     return transformer.keysTransformer();

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/VeteranVerificationConfigTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/VeteranVerificationConfigTest.java
@@ -6,6 +6,7 @@ import gov.va.api.lighthouse.bgs.SoapBenefitsGatewayServicesClient;
 import gov.va.api.lighthouse.emis.SoapEmisMilitaryInformationServiceClient;
 import gov.va.api.lighthouse.emis.SoapEmisVeteranStatusServiceClient;
 import gov.va.api.lighthouse.mpi.SoapMasterPatientIndexClient;
+import gov.va.api.lighthouse.veteranverification.service.utils.JwksProperties;
 import org.junit.jupiter.api.Test;
 
 public class VeteranVerificationConfigTest {
@@ -14,7 +15,11 @@ public class VeteranVerificationConfigTest {
           TestUtils.makeMpiConfig(),
           TestUtils.makeEmisConfig(),
           TestUtils.makeEmisConfigV2(),
-          TestUtils.makeBgsConfig());
+          TestUtils.makeBgsConfig(),
+          "fake",
+          "secret",
+          "secret",
+          "src/test/resources/fakekeystore.jks");
 
   @Test
   void bgsClient() {
@@ -32,6 +37,11 @@ public class VeteranVerificationConfigTest {
   void emisMilitaryInformationClient() {
     assertThat(veteranVerificationConfig.emisMilitaryInformationServiceClient())
         .isInstanceOf(SoapEmisMilitaryInformationServiceClient.class);
+  }
+
+  @Test
+  void jwksProperties() {
+    assertThat(veteranVerificationConfig.jwksProperties()).isInstanceOf(JwksProperties.class);
   }
 
   @Test

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysControllerTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysControllerTest.java
@@ -1,0 +1,41 @@
+package gov.va.api.lighthouse.veteranverification.service.controller.keys;
+
+import gov.va.api.lighthouse.veteranverification.api.v0.JwkKeyset;
+import gov.va.api.lighthouse.veteranverification.service.utils.JwksProperties;
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class KeysControllerTest {
+  @Test
+  @SneakyThrows
+  public void happyPath() {
+    KeyStore ks = KeyStore.getInstance("jks");
+    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
+    KeysController keysController = new KeysController(new JwksProperties(ks, "fake", "secret"));
+    JwkKeyset keySet = keysController.keyset();
+    Assertions.assertEquals(1, keySet.getKeys().size());
+    Assertions.assertEquals("RS256", keySet.getKeys().get(0).getAlg());
+    Assertions.assertEquals("fake", keySet.getKeys().get(0).getKid());
+    Assertions.assertEquals("AQAB", keySet.getKeys().get(0).getExponent());
+    Assertions.assertEquals(
+        "-----BEGIN PUBLIC KEY-----\n"
+            + "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl0HEtNs2NuvF20jd9cmw\n"
+            + "A1gtIUv+mpPpHkQcMU5Mx/EkLxWwwu1kZUMfrEGungdaf/SkN6/1/6Q2/4zxy1eJ\n"
+            + "qYz9xabxGC3QuEsUs1pzoVyS3OwPtnoWa1qpToUs0hxDSWJCdJ9NpGO4CZ//KtTE\n"
+            + "Lxq9Ym9ceho+YIUUO0RrLXl/3x1sAjay8ejSDxM3ld8LGsAskLYcfzlhPhKA36p9\n"
+            + "UFjPzijhQtuMbrczIr1bv+jrVgFOxOj5tiRVARHzhB1ptvS0mD6o5XV161M3TyXa\n"
+            + "egYk7cUfDrhHCxsezFNaSROs7pHm6Rfj1YXA2DiaD6HycXzD2M+wcsUhfPtyIoWb\n"
+            + "kQIDAQAB\n"
+            + "-----END PUBLIC KEY-----",
+        keySet.getKeys().get(0).getPem());
+    Assertions.assertEquals(
+        "l0HEtNs2NuvF20jd9cmwA1gtIUv-mpPpHkQcMU5Mx_EkLxWwwu1kZUMfrEGungdaf_SkN6_1_6Q2_4zxy1eJqYz9x"
+            + "abxGC3QuEsUs1pzoVyS3OwPtnoWa1qpToUs0hxDSWJCdJ9NpGO4CZ__KtTELxq9Ym9ceho-YIUUO0RrLXl_3x1sAja"
+            + "y8ejSDxM3ld8LGsAskLYcfzlhPhKA36p9UFjPzijhQtuMbrczIr1bv-jrVgFOxOj5tiRVARHzhB1ptvS0mD6o5XV16"
+            + "1M3TyXaegYk7cUfDrhHCxsezFNaSROs7pHm6Rfj1YXA2DiaD6HycXzD2M-wcsUhfPtyIoWbkQ",
+        keySet.getKeys().get(0).getModulus());
+  }
+}

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysControllerTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysControllerTest.java
@@ -2,8 +2,6 @@ package gov.va.api.lighthouse.veteranverification.service.controller.keys;
 
 import gov.va.api.lighthouse.veteranverification.api.v0.JwkKeyset;
 import gov.va.api.lighthouse.veteranverification.service.utils.JwksProperties;
-import java.io.FileInputStream;
-import java.security.KeyStore;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -12,9 +10,14 @@ public class KeysControllerTest {
   @Test
   @SneakyThrows
   public void happyPath() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    KeysController keysController = new KeysController(new JwksProperties(ks, "fake", "secret"));
+    KeysController keysController =
+        new KeysController(
+            JwksProperties.builder()
+                .keyStorePath("src/test/resources/fakekeystore.jks")
+                .keyStorePassword("secret")
+                .currentKeyId("fake")
+                .currentKeyPassword("secret")
+                .build());
     JwkKeyset keySet = keysController.keyset();
     Assertions.assertEquals(1, keySet.getKeys().size());
     Assertions.assertEquals("RS256", keySet.getKeys().get(0).getAlg());

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysTransformerTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/controller/keys/KeysTransformerTest.java
@@ -2,8 +2,6 @@ package gov.va.api.lighthouse.veteranverification.service.controller.keys;
 
 import gov.va.api.lighthouse.veteranverification.api.v0.JwkKeyset;
 import gov.va.api.lighthouse.veteranverification.service.utils.JwksProperties;
-import java.io.FileInputStream;
-import java.security.KeyStore;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -12,10 +10,16 @@ public class KeysTransformerTest {
   @Test
   @SneakyThrows
   public void happyPath() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
     KeysTransformer transformer =
-        KeysTransformer.builder().jwksProperties(new JwksProperties(ks, "fake", "secret")).build();
+        KeysTransformer.builder()
+            .jwksProperties(
+                JwksProperties.builder()
+                    .keyStorePath("src/test/resources/fakekeystore.jks")
+                    .keyStorePassword("secret")
+                    .currentKeyId("fake")
+                    .currentKeyPassword("secret")
+                    .build())
+            .build();
     JwkKeyset keySet = transformer.keysTransformer();
     Assertions.assertEquals(1, keySet.getKeys().size());
     Assertions.assertEquals("RS256", keySet.getKeys().get(0).getAlg());

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/JwksPropertiesTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/JwksPropertiesTest.java
@@ -1,9 +1,8 @@
 package gov.va.api.lighthouse.veteranverification.service.utils;
 
 import com.nimbusds.jose.jwk.JWK;
-import java.io.FileInputStream;
+import java.io.IOException;
 import java.security.KeyFactory;
-import java.security.KeyStore;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.List;
@@ -16,60 +15,52 @@ public class JwksPropertiesTest {
   @Test
   @SneakyThrows
   public void currentKeyIdHappyPath() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    JwksProperties jwksProperties =
+        JwksProperties.builder()
+            .keyStorePath("src/test/resources/fakekeystore.jks")
+            .keyStorePassword("secret")
+            .currentKeyId("fake")
+            .currentKeyPassword("secret")
+            .build();
     Assertions.assertEquals("fake", jwksProperties.currentKeyId());
   }
 
   @Test
   @SneakyThrows
-  public void currentKeyIdIsNonNull() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    Assertions.assertThrows(
-        NullPointerException.class,
-        () -> {
-          new JwksProperties(ks, null, "secret");
-        });
-  }
-
-  @Test
-  @SneakyThrows
-  public void currentKeyPasswordIsNonNull() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    Assertions.assertThrows(
-        NullPointerException.class,
-        () -> {
-          new JwksProperties(ks, "fake", null);
-        });
-  }
-
-  @Test
-  @SneakyThrows
   public void currentPrivateJwkHappyPath() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    JwksProperties jwksProperties =
+        JwksProperties.builder()
+            .keyStorePath("src/test/resources/fakekeystore.jks")
+            .keyStorePassword("secret")
+            .currentKeyId("fake")
+            .currentKeyPassword("secret")
+            .build();
     Assertions.assertNotNull(jwksProperties.currentPrivateJwk());
   }
 
   @Test
   @SneakyThrows
   public void currentPublicJwkHappyPath() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    JwksProperties jwksProperties =
+        JwksProperties.builder()
+            .keyStorePath("src/test/resources/fakekeystore.jks")
+            .keyStorePassword("secret")
+            .currentKeyId("fake")
+            .currentKeyPassword("secret")
+            .build();
     Assertions.assertNotNull(jwksProperties.currentPublicJwk());
   }
 
   @Test
   @SneakyThrows
   public void jwkPublicPemHappy() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    JwksProperties jwksProperties =
+        JwksProperties.builder()
+            .keyStorePath("src/test/resources/fakekeystore.jks")
+            .keyStorePassword("secret")
+            .currentKeyId("fake")
+            .currentKeyPassword("secret")
+            .build();
     String publicKeyPEM =
         jwksProperties
             .jwkPublicPem("fake")
@@ -79,7 +70,7 @@ public class JwksPropertiesTest {
     byte[] encoded = Base64.decodeBase64(publicKeyPEM);
     KeyFactory keyFactory = KeyFactory.getInstance("RSA");
     X509EncodedKeySpec keySpec = new X509EncodedKeySpec(encoded);
-    // This would fail if a non public key was being return
+    // This would fail if a non public key was returned
     RSAPublicKey key = (RSAPublicKey) keyFactory.generatePublic(keySpec);
     Assertions.assertNotNull(key);
   }
@@ -87,9 +78,15 @@ public class JwksPropertiesTest {
   @Test
   @SneakyThrows
   public void jwksPrivateHappyPath() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    List<JWK> keys = new JwksProperties(ks, "fake", "secret").jwksPrivate().getKeys();
+    List<JWK> keys =
+        JwksProperties.builder()
+            .keyStorePath("src/test/resources/fakekeystore.jks")
+            .keyStorePassword("secret")
+            .currentKeyId("fake")
+            .currentKeyPassword("secret")
+            .build()
+            .jwksPrivate()
+            .getKeys();
     Assertions.assertEquals(1, keys.size());
     Assertions.assertEquals("RSA", keys.get(0).getKeyType().toString());
     Assertions.assertEquals(
@@ -102,10 +99,91 @@ public class JwksPropertiesTest {
 
   @Test
   @SneakyThrows
+  public void jwksPropertiesBuilderBadKeyStorePathThrowsException() {
+    Assertions.assertThrows(
+        IOException.class,
+        () -> {
+          JwksProperties.builder()
+              .keyStorePath("bad")
+              .keyStorePassword("secret")
+              .currentKeyId("fake")
+              .currentKeyPassword("secret")
+              .build();
+        });
+  }
+
+  @Test
+  @SneakyThrows
+  public void jwksPropertiesBuilderCurrentIdIsNonNull() {
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          JwksProperties.builder()
+              .keyStorePath("src/test/resources/fakekeystore.jks")
+              .keyStorePassword("secret")
+              .currentKeyId(null)
+              .currentKeyPassword("secret")
+              .build();
+        });
+  }
+
+  @Test
+  @SneakyThrows
+  public void jwksPropertiesBuilderCurrentKeyPasswordIsNonNull() {
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          JwksProperties.builder()
+              .keyStorePath("src/test/resources/fakekeystore.jks")
+              .keyStorePassword("secret")
+              .currentKeyId("fake")
+              .currentKeyPassword(null)
+              .build();
+        });
+  }
+
+  @Test
+  @SneakyThrows
+  public void jwksPropertiesBuilderKeyStorePasswordIsNonNull() {
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          JwksProperties.builder()
+              .keyStorePath("src/test/resources/fakekeystore.jks")
+              .keyStorePassword(null)
+              .currentKeyId("fake")
+              .currentKeyPassword("secret")
+              .build();
+        });
+  }
+
+  @Test
+  @SneakyThrows
+  public void jwksPropertiesBuilderKeyStorePathIsNonNull() {
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> {
+          JwksProperties.builder()
+              .keyStorePath(null)
+              .keyStorePassword("secret")
+              .currentKeyId("fake")
+              .currentKeyPassword("secret")
+              .build();
+        });
+  }
+
+  @Test
+  @SneakyThrows
   public void jwksPublicHappyPath() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    List<JWK> keys = new JwksProperties(ks, "fake", "secret").jwksPublic().getKeys();
+    List<JWK> keys =
+        JwksProperties.builder()
+            .keyStorePath("src/test/resources/fakekeystore.jks")
+            .keyStorePassword("secret")
+            .currentKeyId("fake")
+            .currentKeyPassword("secret")
+            .build()
+            .jwksPublic()
+            .getKeys();
     Assertions.assertEquals(1, keys.size());
     Assertions.assertEquals("RSA", keys.get(0).getKeyType().toString());
     Assertions.assertEquals(
@@ -119,18 +197,13 @@ public class JwksPropertiesTest {
   @Test
   @SneakyThrows
   public void jwksPublicJsonHappyPath() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    JwksProperties jwksProperties =
+        JwksProperties.builder()
+            .keyStorePath("src/test/resources/fakekeystore.jks")
+            .keyStorePassword("secret")
+            .currentKeyId("fake")
+            .currentKeyPassword("secret")
+            .build();
     Assertions.assertNotNull(jwksProperties.jwksPublicJson());
-  }
-
-  @Test
-  public void keyStoreIsNonNull() {
-    Assertions.assertThrows(
-        NullPointerException.class,
-        () -> {
-          new JwksProperties(null, "fake", "secret");
-        });
   }
 }

--- a/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
+++ b/veteran-verification/src/test/java/gov/va/api/lighthouse/veteranverification/service/utils/NotaryTest.java
@@ -2,8 +2,6 @@ package gov.va.api.lighthouse.veteranverification.service.utils;
 
 import gov.va.api.lighthouse.veteranverification.api.v0.ServiceHistoryResponse;
 import gov.va.api.lighthouse.veteranverification.service.TestUtils;
-import java.io.FileInputStream;
-import java.security.KeyStore;
 import java.util.Arrays;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
@@ -29,9 +27,13 @@ public class NotaryTest {
         ServiceHistoryResponse.builder()
             .data(Arrays.stream(serviceHistoryEpisodes).toList())
             .build();
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "secret");
+    JwksProperties jwksProperties =
+        JwksProperties.builder()
+            .keyStorePath("src/test/resources/fakekeystore.jks")
+            .keyStorePassword("secret")
+            .currentKeyId("fake")
+            .currentKeyPassword("secret")
+            .build();
     Notary notary = new Notary(jwksProperties);
     String jwt = notary.objectToJwt(serviceHistoryResponse);
     Assertions.assertEquals(
@@ -54,9 +56,13 @@ public class NotaryTest {
   @Test
   @SneakyThrows
   public void objectToJwtObjectIsNonNull() {
-    KeyStore ks = KeyStore.getInstance("jks");
-    ks.load(new FileInputStream("src/test/resources/fakekeystore.jks"), "secret".toCharArray());
-    JwksProperties jwksProperties = new JwksProperties(ks, "fake", "fake");
+    JwksProperties jwksProperties =
+        JwksProperties.builder()
+            .keyStorePath("src/test/resources/fakekeystore.jks")
+            .keyStorePassword("secret")
+            .currentKeyId("fake")
+            .currentKeyPassword("secret")
+            .build();
     Notary notary = new Notary(jwksProperties);
     Assertions.assertThrows(
         NullPointerException.class,


### PR DESCRIPTION
# Description

Create Keys Controller.

## Quick Start

Add following properties to application-dev.properties

```
jwk-set.keystore-path=lighthouse-veteran-verification/veteran-verification/src/test/resources/fakekeystore.jks
jwk-set.current-password=secret
jwk-set.current-key-id=fake
jwk-set.keystore-password=secret
```

```sh
curl -s -H 'Accept: application/json' http://localhost:8080/v0/keys | jq .
```

## Related PRs

https://github.com/department-of-veterans-affairs/lighthouse-veteran-verification-deployment/pull/25

I have verified the keys endpoint is identical to the sandbox keys endpoint when using the deployment values.